### PR TITLE
Trim attributes names as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
 
 			if(attr !== ''){
 				returnArray.push({
-					"attribute": attr,
+					"attribute": attr.trim(),
 					"value": part.substr(attrColon+1).trim()
 				});
 			}


### PR DESCRIPTION
The attributes names also tend to have unwieldy whitespace around them.  I can't think of any reason not to trim the names (even more so than the values).